### PR TITLE
Remove a bit of cargo-culting

### DIFF
--- a/app/shadow-cljs.edn
+++ b/app/shadow-cljs.edn
@@ -6,6 +6,5 @@
                 :release {:output-dir "public-release/js"}
                 :dev {:compiler-options
                       {:reader-features #{:dev-config}}}
-                :js-options {:entry-keys ["module" "browser" "main"]
-                             :export-conditions ["module" "import" "browser" "require" "default"]}}}
+                :js-options {:entry-keys ["module" "browser" "main"]}}}
  :dev-http {8000 "public"}}


### PR DESCRIPTION
The `:export-conditions` part wasn't required for compilation to work. Neither is it documented anywhere in ShadowCLJS's [user guide](https://shadow-cljs.github.io/docs/UsersGuide).